### PR TITLE
32 delete items sendlist view

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -48,6 +48,10 @@ class ItemsController < ApplicationController
   end
 
   def set_item
-    @item = current_user.items.find(params[:id])
+    @item = current_user.items.find_by(id: params[:id])
+    unless @item
+      redirect_to items_path, alert: '指定されたアイテムにはアクセスできません。'
+    end
   end
+
 end

--- a/app/views/send_lists/index.html.erb
+++ b/app/views/send_lists/index.html.erb
@@ -10,7 +10,6 @@
             <th class="px-6 py-3">送信先番号</th>
             <th class="px-6 py-3">送信日時</th>
             <th class="px-6 py-3">動画タイトル</th>
-            <th class="px-6 py-3">動画ID</th>
             <th class="px-6 py-3">送信者</th>
           </tr>
         </thead>
@@ -18,12 +17,15 @@
           <% @send_lists.each_with_index do |send_list, index| %>
             <tr>
               <th class="px-6 py-4"><%= index + 1 %></th>
-              <%# プライバシーに配慮して文字化け %>
               <td class="px-6 py-4"><%= mask_phone_number(send_list.phone_number) %></td>
-              <%# UTCからJST（東京時刻）に変換 %>
               <td class="px-6 py-4"><%= send_list.send_at.in_time_zone('Tokyo').strftime('%Y-%m-%d %H:%M:%S') %></td>
-              <td class="px-6 py-4"><%= send_list.item.title %></td>
-              <td class="px-6 py-4"><%= get_youtube_shorts_id(send_list.item.item_url) %></td>
+              <td class="px-6 py-4">
+                <% if send_list.item %>
+                  <%= link_to send_list.item.title, item_path(send_list.item) %>
+                <% else %>
+                  削除されたアイテム
+                <% end %>
+              </td>
               <td class="px-6 py-4"><%= send_list.sender %></td>
             </tr>
           <% end %>

--- a/db/migrate/20240625211939_change_foreign_key_for_send_lists.rb
+++ b/db/migrate/20240625211939_change_foreign_key_for_send_lists.rb
@@ -1,0 +1,4 @@
+class ChangeForeignKeyForSendLists < ActiveRecord::Migration[7.1]
+  def change
+  end
+end

--- a/db/migrate/20240625211939_change_foreign_key_for_send_lists.rb
+++ b/db/migrate/20240625211939_change_foreign_key_for_send_lists.rb
@@ -1,4 +1,9 @@
-class ChangeForeignKeyForSendLists < ActiveRecord::Migration[7.1]
+class ChangeForeignKeyForSendLists < ActiveRecord::Migration[6.0]
   def change
+    # 外部キー制約を削除
+    remove_foreign_key :send_lists, :items
+
+    # 外部キーを再設定（nullを許可）
+    add_foreign_key :send_lists, :items, on_delete: :nullify
   end
 end

--- a/db/migrate/20240625213944_remove_not_null_constraint_from_item_id_in_send_lists.rb
+++ b/db/migrate/20240625213944_remove_not_null_constraint_from_item_id_in_send_lists.rb
@@ -1,0 +1,5 @@
+class RemoveNotNullConstraintFromItemIdInSendLists < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :send_lists, :item_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_23_233732) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_25_211939) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -53,6 +53,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_23_233732) do
   end
 
   add_foreign_key "items", "users"
-  add_foreign_key "send_lists", "items"
+  add_foreign_key "send_lists", "items", on_delete: :nullify
   add_foreign_key "send_lists", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_25_211939) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_25_213944) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,7 +25,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_25_211939) do
   end
 
   create_table "send_lists", force: :cascade do |t|
-    t.bigint "item_id", null: false
+    t.bigint "item_id"
     t.bigint "user_id", null: false
     t.string "phone_number"
     t.datetime "send_at"


### PR DESCRIPTION
send_listテーブルのitem_idカラムにnullを許可し、過去に送信されたことのあるアイテムが削除されたら「削除されたアイテム」と表記できるようにしました。また送信一覧の動画タイトルをハイパーリンク化しました。
