### PR TITLE
51 add test users controller

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,4 +87,5 @@ group :test do
   gem "selenium-webdriver"
   gem 'factory_bot_rails'
   gem "faker"
+  gem "rails-controller-testing"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,6 +237,10 @@ GEM
       activesupport (= 7.1.3.2)
       bundler (>= 1.15.0)
       railties (= 7.1.3.2)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.2.0)
       activesupport (>= 5.0.0)
       minitest
@@ -352,6 +356,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.2)
+  rails-controller-testing
   rails-i18n
   rspec-rails
   selenium-webdriver

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -1,6 +1,6 @@
 # config/initializers/sorcery.rb
 
-Rails.application.config.sorcery.submodules = [:reset_password]  # リセットパスワードモジュールを有効化
+Rails.application.config.sorcery.submodules = [:reset_password, :test_helpers]  # リセットパスワードモジュールを有効化
 
 Rails.application.config.sorcery.configure do |config|
   config.user_config do |user|

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.describe UsersController, type: :request do
+  describe "GET /users/new" do
+    it "returns http success" do
+      get new_user_path
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "POST /users" do
+    context "with valid parameters" do
+      it "creates a new user and redirects to the root path" do
+        expect {
+          post users_path, params: { user: { name: "Test User", email: "test@example.com", password: "Password1!", password_confirmation: "Password1!" } }
+          puts response.body  # エラーメッセージの確認用
+        }.to change(User, :count).by(1)
+        expect(response).to redirect_to(root_path)
+        follow_redirect!
+        expect(response.body).to include("ユーザー登録が成功し、ログインしました")
+      end
+    end
+
+    context "with invalid parameters" do
+      it "does not create a user and re-renders the new template" do
+        expect {
+          post users_path, params: { user: { name: "", email: "test@example.com", password: "password", password_confirmation: "password" } }
+        }.not_to change(User, :count)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response.body).to include("ユーザー登録に失敗しました")
+      end
+    end
+  end
+
+  # describe "PATCH /users/:uuid" do
+  #   let(:user) { create(:user) }
+  
+  #   before do
+  #     login_user(user)
+  #   end
+  
+  #   context "with valid attributes" do
+  #     it "updates the user and redirects" do
+  #       patch user_path(user.uuid), params: { user: { name: "Updated Name" } }
+  #       expect(response).to redirect_to(user_path(user.uuid))
+  #       follow_redirect!
+  #       expect(response.body).to include("更新しました")
+  #     end
+  #   end
+  
+  #   context "with invalid attributes" do
+  #     it "does not update the user and re-renders the edit template" do
+  #       patch user_path(user.uuid), params: { user: { email: nil } }
+  #       expect(response).to render_template(:edit)
+  #       expect(response).to have_http_status(:unprocessable_entity)
+  #     end
+  #   end
+  # end
+  
+  # describe "PATCH /users/:uuid/update_password" do
+  #   let(:user) { create(:user, password: 'old_password') }
+  
+  #   before do
+  #     login_user(user)
+  #   end
+  
+  #   context "with valid password change" do
+  #     it "updates the password and redirects to the login path" do
+  #       patch update_password_user_path(user.uuid), params: { user: { password: "new_password", password_confirmation: "new_password" } }
+  #       expect(response).to redirect_to(login_path)
+  #       follow_redirect!
+  #       expect(response.body).to include('パスワードが更新されました。再ログインしてください。')
+  #     end
+  #   end
+  
+  #   context "with password mismatch" do
+  #     it "does not update the password and redirects to edit password path" do
+  #       patch update_password_user_path(user.uuid), params: { user: { password: "new_password", password_confirmation: "different" } }
+  #       expect(response).to redirect_to(edit_password_user_path(user.uuid))
+  #       follow_redirect!
+  #       expect(response.body).to include('入力されたパスワードが一致しません。')
+  #     end
+  #   end
+  # end  
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -32,30 +32,30 @@ RSpec.describe UsersController, type: :request do
     end
   end
 
-  # describe "PATCH /users/:uuid" do
-  #   let(:user) { create(:user) }
-  
-  #   before do
-  #     login_user(user)
-  #   end
-  
-  #   context "with valid attributes" do
-  #     it "updates the user and redirects" do
-  #       patch user_path(user.uuid), params: { user: { name: "Updated Name" } }
-  #       expect(response).to redirect_to(user_path(user.uuid))
-  #       follow_redirect!
-  #       expect(response.body).to include("更新しました")
-  #     end
-  #   end
-  
-  #   context "with invalid attributes" do
-  #     it "does not update the user and re-renders the edit template" do
-  #       patch user_path(user.uuid), params: { user: { email: nil } }
-  #       expect(response).to render_template(:edit)
-  #       expect(response).to have_http_status(:unprocessable_entity)
-  #     end
-  #   end
-  # end
+  describe "PATCH /users/:uuid" do
+    let(:user) { create(:user, password: 'Test1234!', password_confirmation: 'Test1234!') }
+
+    before do
+      post login_path, params: { email: user.email, password: 'Test1234!' }
+    end
+
+    context "with valid attributes" do
+      it "updates the user and redirects" do
+        patch user_path(user.uuid), params: { user: { name: "Updated Name" } }
+        expect(response).to redirect_to(user_path(user.uuid))
+        follow_redirect!
+        expect(response.body).to include("更新しました")
+      end
+    end
+
+    context "with invalid attributes" do
+      it "does not update the user and re-renders the edit template" do
+        patch user_path(user.uuid), params: { user: { email: nil } }
+        expect(response).to render_template(:edit)
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
   
   # describe "PATCH /users/:uuid/update_password" do
   #   let(:user) { create(:user, password: 'old_password') }

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -2,7 +2,30 @@ require 'rails_helper'
 
 RSpec.describe UsersController, type: :request do
   let(:user) { create(:user, password: 'OldPassword1!', password_confirmation: 'OldPassword1!') }
+  
+  describe 'GET #show' do
+    let(:user) { FactoryBot.create(:user) }
+    let(:other_user) { FactoryBot.create(:user) }
 
+    context 'when the logged in user is the correct user' do
+      before do
+        login_user(user)
+        get user_path(user.uuid)  # 修正: パスを直接指定
+      end
+    end
+
+    context 'when the logged in user is not the correct user' do
+      before do
+        login_user(other_user)
+        get user_path(user.uuid)  # 修正: パスを直接指定
+      end
+
+      it 'redirects to the login page' do
+        expect(response).to redirect_to(login_path)  # ログインページへのリダイレクトを期待
+      end
+    end
+  end
+  
   describe "GET /users/new" do
     it "returns http success" do
       get new_user_path

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     sequence(:email) { |n| "test#{n}@example.com" }
     password { "Password1!" }
     password_confirmation { "Password1!" }
+    uuid { SecureRandom.uuid }  # UUID をランダムに生成
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -42,7 +42,10 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
-  config.include FactoryBot::Syntax::Methods # FactoryBot シンタックスメソッドの組み込み
+  # FactoryBot シンタックスメソッドの組み込み
+  config.include FactoryBot::Syntax::Methods
+  # Sorceryライブラリが提供するテストヘルパーモジュールをRSpecテストで使用できるように設定する
+  config.include Sorcery::TestHelpers::Rails::Controller, type: :controller
 
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -46,6 +46,7 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   # Sorceryライブラリが提供するテストヘルパーモジュールをRSpecテストで使用できるように設定する
   config.include Sorcery::TestHelpers::Rails::Controller, type: :controller
+  config.include Sorcery::TestHelpers::Rails::Integration, type: :request
 
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false


### PR DESCRIPTION
usersコントローラーのテストを追加しました。

1. GET #show
- 正しいユーザーがログインしている場合: ユーザー詳細ページへのアクセスが成功するかどうか。
- 間違ったユーザーがログインしている場合: ログインページへリダイレクトされるかどうか。

2. GET /users/new
- 新規ユーザー登録ページが正常に表示されるかどうか。

3. POST /users
- 有効なパラメータでのユーザー作成: 新しいユーザーがデータベースに追加され、ルートパスへリダイレクトされるかどうか。
- 無効なパラメータでのユーザー作成: ユーザーが作成されずに新規ユーザー登録ページが再表示されるかどうか。

4. PATCH /users/:uuid
- 有効な属性でのユーザー更新: ユーザー情報が更新され、ユーザー詳細ページへリダイレクトされるかどうか。
- 無効な属性でのユーザー更新: ユーザー情報が更新されずに編集ページが再表示されるかどうか。

5. PATCH /users/:uuid/update_password
- 有効なパスワード変更: ユーザーのパスワードが更新され、ログアウト後にログインページへリダイレクトされるかどうか。
- パスワード不一致: パスワードが一致しない場合、パスワード編集ページにリダイレクトされるかどうか。
- 古いパスワードと同じパスワードの再設定: 新しいパスワードが古いパスワードと同じである場合、エラーメッセージと共にパスワード編集ページにリダイレクトされるかどうか。