### PR TITLE
role別に表示するtopページの修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,3 @@
-# app/controllers/application_controller.rb
 class ApplicationController < ActionController::Base
   include SessionsHelper
   before_action :require_login
@@ -9,6 +8,7 @@ class ApplicationController < ActionController::Base
   private
 
   def check_admin_redirect
+    return unless current_user  # ログインしていない場合はチェックしない
     if current_user.admin? && request.path == '/top'
       redirect_to admin_top_path
     end


### PR DESCRIPTION
未ログインユーザーの場合:
- top, privacy_policy, terms_of_use にアクセス可能
- その他のページは login_path にリダイレクト

一般ユーザーの場合:
- 通常の top ページを表示
- 初回ログイン時はパスワード変更を強制
- /admin/top にアクセスしようとすると拒否

管理者の場合:
- top にアクセスすると admin_top_path にリダイレクト
- 管理者専用機能にアクセス可能