### PR TITLE
72 add daily sms count display

### DIFF
--- a/app/controllers/send_lists_controller.rb
+++ b/app/controllers/send_lists_controller.rb
@@ -2,7 +2,10 @@ class SendListsController < ApplicationController
   before_action :set_send_list, only: [:show, :edit, :update]
 
   def index
-    @send_lists = SendList.order(created_at: :desc).page(params[:page]).per(20)
+    @send_lists = SendList.includes(:item)  # N+1クエリ対策
+                         .order(created_at: :desc)
+                         .page(params[:page])
+                         .per(20)
   end
 
   def show; end
@@ -15,41 +18,57 @@ class SendListsController < ApplicationController
 
   def create
     @send_list = SendList.new(send_list_params)
-  
-    if @send_list.phone_number.length != 11 || @send_list.phone_number.scan(/\D/).any?
-      flash[:danger] = '入力に誤りがあります。電話番号はハイフンなしの11桁の数字を入力してください。'
-      redirect_to items_path and return
+    @send_list.user = current_user
+    @send_list.send_at = Time.current
+
+    unless @send_list.valid?
+      flash[:alert] = @send_list.errors.full_messages.join(', ')
+      redirect_to send_lists_path and return
     end
-  
-    sms_sender = SmsSender.new
-    item = Item.find(@send_list.item_id)
-    user_message = User.find(item.user_id).message_template
-    full_body = "#{user_message} Check this out: #{item.item_url}"
-  
+
     begin
+      item = Item.find(@send_list.item_id)
+      sms_sender = SmsSender.new
+      
       response = sms_sender.send_sms(
         to: @send_list.phone_number,
-        body: full_body,
-        item: item
+        body: '',
+        item: item,
+        is_test: params[:send_as_test].present?
       )
-      if response.status == 'queued'
-        @send_list.user = current_user
-        @send_list.send_at = Time.zone.now
-        if @send_list.save
-          redirect_to send_lists_path, success: 'SMSを送信しました。'
-        else
-          redirect_to send_lists_path, danger: 'SendListの保存に失敗しました。'
-        end
+
+      if response&.status == 'queued'
+        @send_list.save!
+        flash[:notice] = @send_list.send_as_test ? 'テストSMSを送信しました' : 'SMSを送信しました'
       else
-        redirect_to send_lists_path, danger: 'SMSの送信に失敗しました。'
+        flash[:alert] = 'SMSの送信に失敗しました'
       end
+
+    rescue ActiveRecord::RecordNotFound
+      flash[:alert] = 'アイテムが見つかりませんでした'
+    rescue Twilio::REST::TwilioError => e
+      flash[:alert] = "SMS送信エラー: #{e.message}"
+      Rails.logger.error "Twilioエラー: #{e.message}"
     rescue StandardError => e
-      logger.error "SMS sending failed: #{e.message}"
-      redirect_to send_lists_path, danger: 'SMS送信中にエラーが発生しました。'
+      flash[:alert] = 'エラーが発生しました'
+      Rails.logger.error "予期せぬエラー: #{e.class} - #{e.message}"
+      Rails.logger.error e.backtrace.join("\n")
+    end
+
+    redirect_to send_lists_path
+  end
+
+  def update; end
+
+  def check_send_limit
+    if current_user.demo? && current_user.todays_send_count >= User::DEMO_DAILY_LIMIT
+      next_reset = Time.current.beginning_of_day + User::RESET_HOUR.hours + User::RESET_MINUTE.minutes
+      next_reset += 1.day if Time.current >= next_reset
+      
+      flash[:alert] = "本日の送信可能回数（#{User::DEMO_DAILY_LIMIT}回）を超えました。"
+      redirect_to send_lists_path and return
     end
   end
-  
-  def update; end
 
   private
 
@@ -58,6 +77,7 @@ class SendListsController < ApplicationController
   end
 
   def send_list_params
-    params.require(:send_list).permit(:phone_number, :sender, :item_id, :send_at, :send_as_test)
+    params.permit(:phone_number, :sender, :item_id, :send_at, :send_as_test)
   end
+  
 end

--- a/app/controllers/send_lists_controller.rb
+++ b/app/controllers/send_lists_controller.rb
@@ -65,7 +65,7 @@ class SendListsController < ApplicationController
       next_reset = Time.current.beginning_of_day + User::RESET_HOUR.hours + User::RESET_MINUTE.minutes
       next_reset += 1.day if Time.current >= next_reset
       
-      flash[:alert] = "本日の送信可能回数（#{User::DEMO_DAILY_LIMIT}回）を超えました。"
+      flash[:alert] = "1日の送信可能回数（#{User::DEMO_DAILY_LIMIT}回）を超えました。"
       redirect_to send_lists_path and return
     end
   end

--- a/app/models/send_list.rb
+++ b/app/models/send_list.rb
@@ -2,24 +2,65 @@ class SendList < ApplicationRecord
   belongs_to :item
   belongs_to :user
 
-  validates :phone_number, presence: true
+  # バリデーション
+  validates :phone_number, presence: true,
+                         format: { with: /\A\d{11}\z/, message: 'は11桁の数字で入力してください' }
   validates :sender, presence: true
+  validates :send_at, presence: true
 
+  # スコープ定義
   scope :test_sends, -> { where(send_as_test: true) }
   scope :actual_sends, -> { where(send_as_test: false) }
-  
-  # 特定ユーザーの送信回数を取得
-  def self.count_for_user(user_id, include_test: true)
-    scope = where(user_id:)
-    scope = scope.actual_sends unless include_test
-    scope.count
+  scope :in_period, ->(start_date, end_date) {
+    where(created_at: start_date.beginning_of_day..end_date.end_of_day)
+  }
+  scope :for_user, ->(user_id) { where(user_id: user_id) }
+
+  # クラスメソッド
+  class << self
+    def count_for_user(user_id, include_test: true)
+      scope = for_user(user_id)
+      scope = scope.actual_sends unless include_test
+      scope.count
+    end
+
+    def count_for_period(user_id, start_date, end_date, include_test: true)
+      scope = for_user(user_id).in_period(start_date, end_date)
+      scope = scope.actual_sends unless include_test
+      scope.count
+    end
+
+    def daily_stats(user_id, days = 30)
+      start_date = days.days.ago.beginning_of_day
+      for_user(user_id)
+        .where('created_at >= ?', start_date)
+        .group('DATE(created_at)')
+        .select('DATE(created_at) as date, COUNT(*) as total_count, ' \
+                'SUM(CASE WHEN send_as_test THEN 1 ELSE 0 END) as test_count')
+    end
   end
 
-  # 期間指定での送信回数取得
-  def self.count_for_period(user_id, start_date, end_date, include_test: true)
-    scope = where(user_id:)
-            .where(created_at: start_date.beginning_of_day..end_date.end_of_day)
-    scope = scope.actual_sends unless include_test
-    scope.count
+  # インスタンスメソッド
+  def test_send?
+    send_as_test
+  end
+
+  def formatted_phone_number
+    return unless phone_number
+    # 電話番号を整形（例：090-1234-5678）
+    phone_number.gsub(/(\d{3})(\d{4})(\d{4})/, '\1-\2-\3')
+  end
+
+  def send_status
+    test_send? ? 'テスト送信' : '本番送信'
+  end
+
+  private
+
+  def validate_phone_number_format
+    return if phone_number.blank?
+    unless phone_number.match?(/\A\d{11}\z/)
+      errors.add(:phone_number, 'は11桁の数字で入力してください')
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,7 +79,7 @@ class User < ApplicationRecord
   def todays_send_count
     last_reset = Time.current.beginning_of_day + RESET_HOUR.hours + RESET_MINUTE.minutes
     next_reset = last_reset + 1.day
-    
+
     if Time.current < last_reset
       last_reset -= 1.day
       next_reset -= 1.day

--- a/app/services/sms_sender.rb
+++ b/app/services/sms_sender.rb
@@ -1,28 +1,55 @@
 class SmsSender
   def initialize
-    @client = Twilio::REST::Client.new(ENV['TWILIO_ACCOUNT_SID'], ENV['TWILIO_AUTH_TOKEN'])
+    @client = Twilio::REST::Client.new(
+      ENV['TWILIO_ACCOUNT_SID'],
+      ENV['TWILIO_AUTH_TOKEN']
+    )
   end
 
-  def send_sms(to:, body:, item:)
+  def send_sms(to:, body:, item:, is_test: false)
     formatted_phone_number = format_phone_number(to)
     return unless formatted_phone_number
 
-    user_message = User.find(item.user_id).message_template
-    full_body = "#{user_message} #{item.item_url} 身に覚えのない場合は無視してください。"
-
-    @client.messages.create(
-      from: ENV['TWILIO_PHONE_NUMBER'],
-      to: formatted_phone_number,
-      body: full_body
-    )
+    begin
+      Rails.logger.info "Twilioクレデンシャル確認: SID=#{ENV['TWILIO_ACCOUNT_SID']&.first(6)}..."
+      Rails.logger.info "送信元番号: #{ENV['TWILIO_PHONE_NUMBER']}"
+      
+      # メッセージ本文を構築
+      message_body = build_message(item, is_test)
+      
+      response = @client.messages.create(
+        from: ENV['TWILIO_PHONE_NUMBER'],
+        to: formatted_phone_number,
+        body: message_body
+      )
+      
+      Rails.logger.info "Twilioレスポンス: #{response.status}"
+      response
+      
+    rescue => e
+      Rails.logger.error "Twilioエラー詳細: #{e.class}: #{e.message}"
+      Rails.logger.error e.backtrace.join("\n")
+      raise
+    end
   end
 
   private
 
-  # 電話番号を国際形式にフォーマット
-  def format_phone_number(phone_number)
-    phone_number = phone_number.gsub(/\D/, '') # 数字のみ取り出す
-    return nil unless phone_number.length == 10 || phone_number.length == 11
-    "+81#{phone_number[1..]}"
+  def format_phone_number(number)
+    return unless number.present?
+    number = number.gsub(/[-\s]/, '')
+    number = "+81#{number[1..-1]}" if number.start_with?('0')
+    number
+  end
+
+  def build_message(item, is_test)
+    # テストメッセージの場合は先頭に[テスト]を付ける
+    prefix = is_test ? "[テスト] " : ""
+    
+    # メッセージ本文を構築
+    message = "#{prefix}#{item.user.name}から送信されました。\n"
+    message += "#{item.item_url}"
+
+    message
   end
 end

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -15,13 +15,13 @@
           <%= link_to item.title, item_path(item), class: "block" %>
         </div>
         <%# タグリストを表示しない %>
-        
+                <!--
         <div>
           <% item.tag_list.each do |tag| %>
             <%= link_to tag, items_path(tag: tag), class: "badge rounded-full bg-blue-500 hover:bg-blue-700 text-white px-3 py-1 text-xs no-underline" %>
           <% end %>
         </div>
-        
+        -->
         <br>
         <div class="flex justify-end">
           <button class="btn btn-primary" onclick="document.getElementById('sendModal-<%= item.id %>').showModal()">
@@ -33,26 +33,27 @@
             <button class="btn btn-sm btn-circle absolute right-2 top-2" onclick="document.getElementById('sendModal-<%= item.id %>').close()">✕</button>
             <h3 class="font-bold text-lg mb-4">送信フォーム</h3>
             <form method="post" action="<%= send_sms_path %>" class="flex flex-col items-center gap-4">
-              <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
-              <input type="hidden" name="item_id" value="<%= item.id %>">
-              <div class="w-full max-w-xs">
-                <label class="label block text-left">送信先電話番号:</label>
-                <input type="text" placeholder="ハイフンなし" name="phone_number" class="input input-bordered w-full" required>
-              </div>
-              <div class="w-full max-w-xs">
-                <label class="label block text-left">送信者名:</label>
-                <input type="text" placeholder="送信者名を入力" name="sender_name" class="input input-bordered w-full" required>
-              </div>
-              <div class="w-full max-w-xs">
-                <div class="flex items-center">
-                  <label>テスト送信</label>
-                  <input type="checkbox" name="send_as_test" class="checkbox checkbox-primary" style="margin-left: 16px;">
-                </div>
-              </div>
-              <div class="modal-action">
-                <input type="submit" value="送信する" class="btn btn-primary">
-              </div>
-            </form>
+  <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+  <input type="hidden" name="item_id" value="<%= item.id %>">
+  <div class="w-full max-w-xs">
+    <label class="label block text-left">送信先電話番号:</label>
+    <input type="text" placeholder="ハイフンなし" name="phone_number" class="input input-bordered w-full" required>
+  </div>
+  <div class="w-full max-w-xs">
+    <label class="label block text-left">送信者名:</label>
+    <input type="text" placeholder="送信者名を入力" name="sender" class="input input-bordered w-full" required>
+  </div>
+  <div class="w-full max-w-xs">
+    <div class="flex items-center">
+      <label>テスト送信</label>
+      <input type="checkbox" name="send_as_test" class="checkbox checkbox-primary" style="margin-left: 16px;">
+    </div>
+  </div>
+  <div class="modal-action">
+    <input type="submit" value="送信する" class="btn btn-primary">
+  </div>
+</form>
+
           </div>
         </dialog>
       </div>

--- a/app/views/send_lists/index.html.erb
+++ b/app/views/send_lists/index.html.erb
@@ -1,8 +1,10 @@
 <div class="mx-5 mt-5 sm:mt-20" data-controller="video-preview">
-  <h1 class="text-2xl font-bold my-20 text-center">送信結果一覧</h1>
-
+  <h1 class="text-2xl font-bold my-20 text-center">
+    送信履歴<%= render 'shared/sms_counter' %>
+  </h1>
   <div class="container px-10 pt-20 pb-20 mx-auto bg-slate-40 rounded-md shadow-md my-10">
     <div class="overflow-x-auto">
+      
       <table class="table table-lg">
         <thead>
           <tr class="bg-gray-100">
@@ -41,7 +43,6 @@
         </tbody>
         <tfoot></tfoot>
       </table>
-      <!-- ページネーションコントロールを追加 -->
       <div class="flex justify-center mt-10 mb-20">
         <%= paginate @send_lists %>
       </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -34,7 +34,7 @@
             </ul>
         </div>
 
-        <%= link_to '送信一覧', send_lists_path, class: "text-gray-700 hover:text-gray-900" %>
+        <%= link_to '送信履歴', send_lists_path, class: "text-gray-700 hover:text-gray-900" %>
       <% end %>
 
       <div class="dropdown dropdown-bottom dropdown-end" style="z-index: 200;">

--- a/app/views/shared/_sms_counter.html.erb
+++ b/app/views/shared/_sms_counter.html.erb
@@ -1,0 +1,7 @@
+<div class="sms-counter bg-white p-3 rounded-lg shadow-sm inline-block">
+  <% if current_user.demo? %>
+    <span class="text-gray-700">本日の送信回数: <span class="font-semibold"><%= current_user.todays_send_count %>/5</span> 回</span>
+  <% else %>
+    <span class="text-gray-700">本日の送信回数: <span class="font-semibold"><%= current_user.todays_send_count %></span> 回</span>
+  <% end %>
+</div>

--- a/app/views/shared/_sms_counter.html.erb
+++ b/app/views/shared/_sms_counter.html.erb
@@ -1,7 +1,7 @@
 <div class="sms-counter bg-white p-3 rounded-lg shadow-sm inline-block">
   <% if current_user.demo? %>
-    <span class="text-gray-700">本日の送信回数: <span class="font-semibold"><%= current_user.todays_send_count %>/5</span> 回</span>
+    <span class="text-gray-700">本日 <span class="font-semibold"><%= current_user.todays_send_count %>/5</span> 回</span>
   <% else %>
-    <span class="text-gray-700">本日の送信回数: <span class="font-semibold"><%= current_user.todays_send_count %></span> 回</span>
+    <span class="text-gray-700">本日 <span class="font-semibold"><%= current_user.todays_send_count %></span> 回</span>
   <% end %>
 </div>


### PR DESCRIPTION
- 全ユーザーの送信回数が表示される
- デモユーザーのみ1日に5回の送信制限（定数として管理）
- 一般ユーザーとadminユーザーは無制限に送信可能
- エラーハンドリングの強化
- テストメッセージの場合は先頭に[テスト]が付く
- 送信回数のリセット時刻を8:30に設定