### PR TITLE
81 fix tag case sensitivity

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -45,7 +45,7 @@ class ItemsController < ApplicationController
     @item = current_user.items.new(item_params)
     
     # タグの処理をモデルに委譲
-    @item.normalized_tag_list = item_params[:tag_list]
+    # @item.normalized_tag_list = item_params[:tag_list]
 
     video_id = @item.send(:extract_video_id, @item.item_url)
     existing_item = if current_user.can_view_all_items?
@@ -72,7 +72,7 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
     
     # タグの処理をモデルに委譲
-    @item.normalized_tag_list = item_params[:tag_list] if item_params[:tag_list].present?
+    # @item.normalized_tag_list = item_params[:tag_list] if item_params[:tag_list].present?
     
     # 更新前に重複チェック
     video_id = @item.send(:extract_video_id, item_params[:item_url])

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -28,7 +28,7 @@
           <%= f.text_field :tag_list, 
                    class: "w-full input input-bordered input-primary mt-1 placeholder:text-xs", 
                    value: @item.tag_list.join("、"), 
-                   placeholder: 'スペース 読点(、) カンマ(,)のいずれかで区切る' %>
+                   placeholder: '読点(、) カンマ(,) 半角スラッシュ(/)で区切る' %>
         </div>
 
         <div class="mb-4">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -15,21 +15,25 @@
             <%= @item.description %>
           </div>
         </div>
+
+        <!-- タグ表示部分 -->
         <div class="mb-4">
           <label class="block text-gray-700">タグ</label>
           <div class="w-full input input-bordered input-primary-content mt-1 p-2 bg-white flex flex-wrap gap-2">
             <% @item.tag_list.each do |tag| %>
-              <%= link_to tag, items_path(tag: tag), class: "badge rounded-full bg-blue-500 hover:bg-blue-700 text-white px-4 py-2 text-lg no-underline" %>
+              <%= link_to tag, items_path(tag: tag), class: "badge bg-blue-500 text-white whitespace-nowrap px-3 py-1 text-sm rounded-full" %>
             <% end %>
           </div>
         </div>
+
+        <!-- 動画URL表示部分 -->
         <div class="mb-4">
           <label class="block text-gray-700">動画URL</label>
-          <div class="w-full input input-bordered input-primary-content mt-1 p-2 bg-white h-32 flex items-center break-all">
+          <div class="w-full input input-bordered input-primary-content mt-1 p-2 bg-white min-h-[4.5rem] max-h-[4.5rem] overflow-y-auto break-all">
             <%= @item.item_url %>
           </div>
         </div>
-        
+
         <!-- 編集・削除ボタンの条件分岐 -->
         <div class='flex justify-end space-x-2 mt-4'>
           <% unless current_user.demo? %>

--- a/config/initializers/acts_as_taggable_on.rb
+++ b/config/initializers/acts_as_taggable_on.rb
@@ -1,2 +1,2 @@
-ActsAsTaggableOn.force_lowercase = true
-ActsAsTaggableOn.force_parameterize = true
+ActsAsTaggableOn.force_lowercase = false
+ActsAsTaggableOn.force_parameterize = false

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -17,6 +17,7 @@ ja:
             tag_list:
               too_many_tags: "は最大3つまでです"
             item_url:
+              duplicate_video: "はすでに登録されています"
               invalid_youtube_shorts_url: "は有効なYouTube Shorts URLである必要があります"
   enums:
     user:


### PR DESCRIPTION
- 半角英数字で書いた文字しかタグとして保存されない。
- 日本語でかいたものはスルーされてしまう。
- 全角英語で書いたものや大文字英語でかいたものは軒並み小文字半角英語に変換されて保存される。

これを解消するために、itemモデルのカスタムメソッドを、config/initializers/acts_as_taggable_on.rbデフォルトのtag_listsメソッドにオーバライドする処理を実装しました。
また、正規化されたタグリストを super で親クラスの tag_list= メソッドに渡すようにしました。