### PR TITLE
83 fix user registration access control

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,12 +1,8 @@
 class UsersController < ApplicationController
   before_action :require_login, except: [:new, :create]
-  # before_action :require_admin, only: [:index, :new, :create, :destroy]
   before_action :set_user, only: [:show, :edit, :update, :edit_password, :update_password]
   before_action :correct_user, only: [:show, :edit, :update, :edit_password, :update_password]
-
-  # def index # indexアクションを削除（管理者機能）
-  #   @users = User.all
-  # end
+  before_action :handle_new_action, only: [:new] 
 
   def show; end
 
@@ -58,6 +54,15 @@ class UsersController < ApplicationController
   end
 
   private
+
+  def handle_new_action
+    if current_user&.admin?
+      redirect_to new_admin_user_path
+    else
+      flash[:notice] = "アクセス権限がありません"
+      redirect_to root_path
+    end
+  end
 
   def password_mismatch?
     params[:user][:password] != params[:user][:password_confirmation]

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -21,9 +21,6 @@
     <br>
     <div class='text-center'>
       <ul class="menu menu-horizontal px-1 font-bold ">
-        <!--
-        <li><%= link_to '新規登録ページへ', new_user_path %></li>
-        -->
         <li><%= link_to 'パスワードをお忘れの方はこちら', new_password_reset_path %></li>
       </ul>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
   end
 
   # 一般ユーザー用のルーティング
-  resources :users, only: [:new, :create, :show, :edit, :update], param: :uuid do
+  resources :users, only: [:show, :edit, :update], param: :uuid do
     member do
       get 'edit_password'
       patch 'update_password'
@@ -27,6 +27,8 @@ Rails.application.routes.draw do
 
   # usersのindexページのリダイレクト（管理者用ルーティングの後に配置）
   get '/users', to: redirect('/')
+  # /users/new へのアクセスを管理者ページまたはホームにリダイレクト
+  get '/users/new', to: redirect('/admin/users/new')  # または to: redirect('/')
 
   resources :items
   resources :send_lists

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
   end
 
   # 一般ユーザー用のルーティング
-  resources :users, only: [:show, :edit, :update], param: :uuid do
+  resources :users, only: [:new, :show, :edit, :update], param: :uuid do
     member do
       get 'edit_password'
       patch 'update_password'


### PR DESCRIPTION
管理者ユーザーは管理者用新規登録ページへリダイレクトし、一般ユーザーには適切なアクセス権限エラーメッセージを表示するように修正しました。