### PR TITLE
SMTPメール設定にドメインパラメータを追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,6 +78,7 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = {
     address: ENV['SMTP_SERVER'],
     port: ENV['SMTP_PORT'].to_i, 
+    domain: ENV['MAIL_HOST'],
     user_name: ENV['SMTP_USERNAME'],
     password: ENV['SMTP_PASSWORD'],
     authentication: 'plain',


### PR DESCRIPTION
- メール送信設定にdomainパラメータを追加
- ENV['MAIL_HOST']を使用してドメインを指定
- SMTP認証の問題を解決するための修正
- パスワードリセットメール送信機能の改善