### PR TITLE
102 share items with general users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,6 +79,22 @@ class User < ApplicationRecord
     SendList.where(user: self, role_at_time: 2).exists?
   end
 
+  def can_edit_item?(item)
+    item.user_id == id
+  end
+
+  def admin?
+    role == 'admin'
+  end
+
+  def demo?
+    role == 'demo'
+  end
+
+  def general?
+    role == 'general'
+  end
+
   private
 
   def ensure_uuid

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -20,7 +20,7 @@
 
         <div class="mb-4">
           <%= f.label :description, '説明', class: "block text-gray-700" %>
-          <%= f.text_area :description, class: "w-full textarea textarea-bordered textarea-primary mt-1 h-32" %>
+          <%= f.text_area :description, class: "w-full textarea textarea-bordered textarea-primary mt-1 h-24" %>
         </div>
 
         <div class="mb-4">
@@ -33,8 +33,19 @@
 
         <div class="mb-4">
           <%= f.label :item_url, "動画URL", class: "block text-gray-700" %>
-          <%= f.text_area :item_url, placeholder: 'YouTube shortsのURLのみ登録可', class: "w-full textarea textarea-bordered textarea-primary mt-1 h-32", data: { video_preview_target: "url" } %>
+          <%= f.text_area :item_url, placeholder: 'YouTube shortsのURLのみ登録可', class: "w-full textarea textarea-bordered textarea-primary mt-1 h-24", data: { video_preview_target: "url" } %>
         </div>
+
+        <!-- 管理者のみ表示する一般公開設定 -->
+        <% if @is_admin %>
+          <div class="form-control">
+            <%= f.label :shared_with_general, class: "flex items-center cursor-pointer" do %>
+              <%= f.check_box :shared_with_general, class: "checkbox checkbox-primary mr-2" %>
+              <span class="label-text">一般ユーザーに公開する</span>
+            <% end %>
+            <p class="text-xs text-gray-500 mt-1">チェックすると、一般ユーザーもこのアイテムを閲覧・使用できるようになります</p>
+          </div>
+        <% end %>
 
         <div class="flex justify-end space-x-2 mt-4">
           <%= f.button type: 'submit', class: 'btn btn-primary' do %>

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -26,9 +26,9 @@
         <div class="mb-4">
           <%= f.label :tag, 'タグ（最大3つまで）', class: "block text-gray-700" %>
           <%= f.text_field :tag_list, 
-                   class: "w-full input input-bordered input-primary mt-1 placeholder:text-xs", 
-                   value: @item.tag_list.join("、"), 
-                   placeholder: '読点(、) カンマ(,) 半角スラッシュ(/)で区切る' %>
+                class: "w-full input input-bordered input-primary mt-1 placeholder:text-xs", 
+                value: @item.tag_list.join("、"), 
+                placeholder: '読点(、) カンマ(,) 半角スラッシュ(/)で区切る' %>
         </div>
 
         <div class="mb-4">

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -36,7 +36,7 @@
           <%= f.text_area :item_url, placeholder: 'YouTube shortsのURLのみ登録可', class: "w-full textarea textarea-bordered textarea-primary mt-1 h-24", data: { video_preview_target: "url" } %>
         </div>
 
-        <!-- 管理者のみ表示する一般公開設定 -->
+        <!-- 管理者のみ表示,一般公開設定 -->
         <% if @is_admin %>
           <div class="form-control">
             <%= f.label :shared_with_general, class: "flex items-center cursor-pointer" do %>

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -19,7 +19,6 @@
           <% end %>
           <br>
         </div>
-
         <div class="flex justify-end">
           <%= render 'shared/sms_button', item: item %>
         </div>

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -14,14 +14,6 @@
         <div class="text-lg font-semibold">
           <%= link_to item.title, item_path(item), class: "block" %>
         </div>
-        <%# タグリストを非表示 %>
-        <!--
-        <div>
-          <% item.tag_list.each do |tag| %>
-            <%= link_to tag, items_path(tag: tag), class: "badge rounded-full bg-blue-500 hover:bg-blue-700 text-white px-3 py-1 text-xs no-underline" %>
-          <% end %>
-        </div>
-        -->
         <br>
         <div class="flex justify-end">
           <%= render 'shared/sms_button', item: item %>

--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -13,8 +13,13 @@
       <div class="mt-4">
         <div class="text-lg font-semibold">
           <%= link_to item.title, item_path(item), class: "block" %>
+          <!-- 管理者共有アイテムの場合はバッジを表示 -->
+          <% if item.user.admin? && item.user_id != current_user.id %>
+            <span class="inline-block bg-gray-500 text-white text-xs px-4 py-0.5 rounded-full ml-1">共通アイテム</span>
+          <% end %>
+          <br>
         </div>
-        <br>
+
         <div class="flex justify-end">
           <%= render 'shared/sms_button', item: item %>
         </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -34,9 +34,14 @@
           </div>
         </div>
 
+        <!-- 管理者共有アイテムの場合はバッジを表示 -->
+        <% if @item.user.admin? && @item.user_id != current_user.id %>
+          <span class="inline-block bg-gray-500 text-white text-xs px-4 py-1 rounded-full font-semibold">共通アイテム</span>
+        <% end %>
+
         <!-- 編集・削除ボタンの条件分岐 -->
         <div class='flex justify-end space-x-2 mt-4'>
-          <% unless current_user.demo? %>
+          <% if current_user.can_edit_item?(@item) && !current_user.demo? %>
             <%= link_to edit_item_path(@item), class: "btn btn bg-gray-500", id: "button-edit-#{@item.id}" do %>
               <i class="ph ph-note-pencil large-icon"></i> 編集
             <% end %>

--- a/db/migrate/20250330023739_add_shared_with_general_to_items.rb
+++ b/db/migrate/20250330023739_add_shared_with_general_to_items.rb
@@ -1,0 +1,6 @@
+class AddSharedWithGeneralToItems < ActiveRecord::Migration[7.1]
+  def change
+    add_column :items, :shared_with_general, :boolean, default: false, null: false
+    add_index :items, :shared_with_general
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_12_14_045602) do
+ActiveRecord::Schema[7.1].define(version: 2025_03_30_023739) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_14_045602) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "shared_with_general", default: false, null: false
+    t.index ["shared_with_general"], name: "index_items_on_shared_with_general"
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 


### PR DESCRIPTION
### 概要
管理者が作成したアイテムを一般ユーザーと共有できる機能を実装。
管理者は特定のアイテムに「一般公開」のフラグを設定でき、一般ユーザーはそれらの共有アイテムを閲覧できるようになる。

### 変更内容
- テーブルの変更
items テーブルに shared_with_general カラム（boolean型、デフォルト false）を追加
- モデル変更
   - User モデルに権限チェック用のヘルパーメソッドを追加
   - can_edit_item?: ユーザーがアイテムを編集できるかチェック
   - admin?, demo?, general?: ユーザーロールを簡単に判定するメソッド
- コントローラー変更
   - ItemsController の権限チェックロジックを更新
   - 一般ユーザーは自分のアイテムと、管理者が共有設定したアイテムのみ閲覧可能
   - 管理者のみが共有設定を変更可能
   - アイテム編集・削除は所有者のみ可能
- ビュー変更
   - アイテム作成/編集フォームに管理者向けの共有設定チェックボックスを追加
   - アイテム一覧と詳細ページに共有状態を示すバッジを追加
   - 編集ボタンの表示条件を所有者のみに制限