### PR TITLE
トップページのレイアウト調整：ヒーロー高さとチャットバブル位置の微調整

### DIFF
--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,5 +1,5 @@
 <div class="hero relative flex flex-col justify-center" 
-     style="height: calc(100vh - 80px - 40px); 
+     style="height: calc(100vh - 80px - 30px); 
             background-image: url(<%= image_url('top.jpg') %>); 
             background-size: cover; 
             background-position: center; 
@@ -19,7 +19,7 @@
   </div>
 
   <% unless logged_in? %>
-    <div class="chat chat-end absolute bottom-0 right-0" style="margin-bottom: 4rem;">
+    <div class="chat chat-end absolute bottom-0 right-0" style="margin-bottom: 5rem;">
       <div class="chat-bubble text-left text-m font-bold" style="max-width: 360px; background-color: rgba(255, 255, 255, 0.9); color: #333;">
         ご質問・お試し利用をご希望の方は<br />
         ページ下　"お問い合わせ"　から！


### PR DESCRIPTION
- ヒーローセクションの高さ計算を調整 (40px → 30px)
- 未ログインユーザー向けチャットバブルの位置を調整 (4rem → 5rem)